### PR TITLE
Launchpad Pro support (and a bunch of refactoring)

### DIFF
--- a/config/apcmini_config.lua
+++ b/config/apcmini_config.lua
@@ -1,7 +1,7 @@
 local apcmini={
   --here we have the 'grid' this looks literally like the grid notes as they are mapped on the apc, they can be changed for other devices
   --note though, that a call to this table will look backwards, i.e, to get the visual x=1 and y=2, you have to enter midigrid[2][1], not the other way around!
-  grid= {{56,57,58,59,60,61,62,63},
+  grid_notes= {{56,57,58,59,60,61,62,63},
     {48,49,50,51,52,53,54,55},
     {40,41,42,43,44,45,46,47},
     {32,33,34,35,36,37,38,39},

--- a/config/launchpad_config.lua
+++ b/config/launchpad_config.lua
@@ -1,7 +1,7 @@
 local launchpad={
   --here we have the 'grid' this looks literally like the grid notes as they are mapped on the apc, they can be changed for other devices
   --note though, that a call to this table will look backwards, i.e, to get the visual x=1 and y=2, you have to enter midigrid[2][1], not the other way around!
-  grid= {
+  grid_notes= {
     { 0, 1, 2, 3, 4, 5, 6, 7},
     {16,17,18,19,20,21,22,23},
     {32,33,34,35,36,37,38,39},

--- a/config/launchpadmk2_config.lua
+++ b/config/launchpadmk2_config.lua
@@ -1,7 +1,7 @@
 local launchpad={
   --here we have the 'grid' this looks literally like the grid notes as they are mapped on the apc, they can be changed for other devices
   --note though, that a call to this table will look backwards, i.e, to get the visual x=1 and y=2, you have to enter midigrid[2][1], not the other way around!
-  grid= {
+  grid_notes= {
     {81,82,83,84,85,86,87,88},
     {71,72,73,74,75,76,77,78},
     {61,62,63,64,65,66,67,68},
@@ -24,7 +24,7 @@ local launchpad={
       return 13
     elseif (val > 5) and (val < 8) then --6--7
       --full yellow
-      return 12 
+      return 12
     elseif (val > 7) and (val < 11) then--8-10
       --low pink
       return 54

--- a/config/launchpadpro_config.lua
+++ b/config/launchpadpro_config.lua
@@ -1,0 +1,121 @@
+local launchpad = {
+    -- here we have the 'grid'. this looks literally like the grid notes as they are on
+    -- the device.
+    -- note though, that a call to this table will look backwards, i.e, to get the
+    -- visual x=1 and y=2, you have to enter midigrid[2][1], not the other way around!
+    grid_notes = {
+        {81, 82, 83, 84, 85, 86, 87, 88},
+        {71, 72, 73, 74, 75, 76, 77, 78},
+        {61, 62, 63, 64, 65, 66, 67, 68},
+        {51, 52, 53, 54, 55, 56, 57, 58},
+        {41, 42, 43, 44, 45, 46, 47, 48},
+        {31, 32, 33, 34, 35, 36, 37, 38},
+        {21, 22, 23, 24, 25, 26, 27, 28},
+        {11, 12, 13, 14, 15, 16, 17, 18}
+    },
+
+
+    --[[ values here correspond to the launchpad pro led settings found in the programmer's
+             reference.
+         HOWEVER, the lp pro can do full rgb, so we'll take andvantage of that. this requires
+             sending sysex, and lets us use the full 16 brightness levels. we'll use a table of
+             values directly indexed by the value passed into the fn
+         NOTE! Individual LED brightnesses only range from 0x0-0x3f (i.e. 0-63); 1/4 the
+            resolution of what we're used to (i.e. 0x0-0xff or 0-255)
+    ]]
+    brightness_handler = function(val)
+        local less_angry_rainbow = {
+            '0x00,0x00,0x00',
+            '0x00,0x09,0x19',
+            '0x05,0x16,0x2f',
+            '0x14,0x18,0x34',
+            '0x08,0x07,0x21',
+            '0x12,0x07,0x21',
+            '0x19,0x04,0x22',
+            '0x29,0x0e,0x2b',
+            '0x1f,0x00,0x1a',
+            '0x30,0x04,0x20',
+            '0x34,0x08,0x19',
+            '0x3f,0x15,0x1b',
+            '0x3f,0x19,0x14',
+            '0x3f,0x20,0x0e',
+            '0x3c,0x26,0x0b',
+            '0x37,0x2d,0x0b'
+        }
+        return less_angry_rainbow[val + 1]
+    end,
+
+    --[[ this is the column of keys on the sides of the grid, not necessary for strict
+         grid emulation but handy!
+         the lp pro round buttons send midi ccs
+    ]]
+    -- top to bottom
+    -- left side
+    auxcol = {80, 70, 60, 50, 40, 30, 20, 10},
+    -- right side
+    auxcol2 = {89, 79, 69, 59, 49, 39, 29, 19},
+    -- left to right
+    -- top
+    auxrow = {91, 92, 93, 94, 95, 96, 97, 98},
+    -- bottom
+    auxrow2 = {1, 2, 3, 4, 5, 6, 7, 8},
+
+    -- here we set the left and right page buttons for two page mode
+    -- we can simply use the cc # as-is
+    leftpage_button = 93,
+    rightpage_button = 94,
+
+    -- table of device-specific capabilities
+    caps = {
+      -- can we use sysex to update the grid leds?
+      sysex = true,
+      -- is this an rgb device?
+      rgb = true,
+      -- do the edge buttons send cc?
+      cc_edge_buttons = true
+    },
+
+
+    split_string = function(color)
+        rgb = {}
+        -- '([^,]+)' regex for 'group match any number of characters which are not `,`'
+        for byte in string.gmatch(color, '([^,]+)') do
+            rgb[#rgb + 1] = byte
+        end
+        return rgb[1], rgb[2], rgb[3]
+    end,
+
+
+    led_sysex = function(self, led, color)
+        local set_led_rgb = '0x0b' -- magic number for "set led rgb"
+        -- `color` is e.g. 'ff,f2,e6'
+        r, g, b = self.split_string(color)
+        return self.do_sysex(set_led_rgb, led, r, g, b)
+    end,
+
+
+    all_led_sysex = function(self, color)
+        local set_all_led_rgb = '0x0e' -- magic number for "set ALL leds"
+        r, g, b = self.split_string(color)
+        return self.do_sysex(set_all_led_rgb, r, g, b)
+    end,
+
+
+    do_sysex = function(command, ...)
+        local var_args = ', '
+        for i = 1, select("#", ...) do
+            var_args = var_args .. string.format('%s, ', select(i, ...))
+        end
+        local end_sysex = '0xf7'
+        local sysex_str = string.format('0xf0, 0x00, 0x20, 0x29, 0x02, 0x10, %s%s%s',
+                                        command, var_args, end_sysex)
+        -- print(sysex_str)
+        sysex = tab.split(sysex_str, ', ')
+        return sysex
+    end,
+
+    -- For unknown reason(s), allows us to use programmer mode
+    device_name = 'launchpad pro 2'
+}
+
+return launchpad

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -43,10 +43,10 @@ function midigrid.connect(dummy_id)
 end
 
 
--- function midigrid.set_key_handler(key_handler)
---     midigrid.set_midi_handler()
---     midigrid.key = key_handler
--- end
+function midigrid.set_key_handler(key_handler)
+    midigrid.set_midi_handler()
+    midigrid.key = key_handler
+end
 
 
 function midigrid.setup_connect_handling()
@@ -146,7 +146,6 @@ end
 
 function midigrid:led(x, y, z)
     if self.device then
-        chan = 1
 
         -- flag reversed here because thats actually what it is in lua table!!!, see above.
         -- this is clearer either way I think
@@ -159,8 +158,7 @@ function midigrid:led(x, y, z)
         else
 
             -- debugger, probably want to comment this out if you are being messyy
-            print("no note found! coordinates....  x:" .. x .. "  y:" .. y ..
-                      "  z:" .. z)
+            print("no note found! coordinates....  x:" .. x .. "  y:" .. y .. "  z:" .. z)
         end
     end
 end
@@ -169,7 +167,6 @@ end
 -- sending our buff
 function midigrid:refresh()
     if self.device then
-        -- self:send(self.ledbuf)
         midi.devices[midigrid.midi_id]:send(self.ledbuf)
         self.ledbuf = {}
     end
@@ -181,16 +178,12 @@ function midigrid:all(vel)
         self.ledbuf = {}
         for x = 1, #gridnotes do
             for y = 1, #gridnotes[x] do
-                chan = 1
                 note = gridnotes[x][y]
                 vel = brightness_handler(vel)
                 table.insert(self.ledbuf, 0x90)
                 table.insert(self.ledbuf, note)
                 table.insert(self.ledbuf, vel)
             end
-            -- it is unclear to me sometimes if a call to all in a regular grid requires a
-            -- subsequent refresh, have this here in cqase
-            -- self:refresh()
         end
     end
 end

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -11,10 +11,23 @@
      does `set_midi_handler()`
 ]]
 
--- loading up config file here
-local config = include('midigrid/config/apcmini_config')
--- local config = include('midigrid/config/launchpad_config')
--- local config = include('midigrid/config/untz_config')
+local supported_devices = {apcmini = 'apcmini',
+                           launchpadmk2 = 'launchpad mk2',
+                           launchpadpro = 'launchpad pro 2',
+                           launchpad = 'launchpad'}
+local config_name = 'none'
+for _, dev in pairs(midi.devices) do
+    local name = string.lower(dev.name)
+    for device, device_name in pairs(supported_devices) do
+        if name == device_name then
+            config_name = 'midigrid/config/' .. device .. '_config'
+        end
+    end
+end
+if config_name == 'none' then
+    print('No supported device found')
+end
+local config = include(config_name)
 local gridnotes = config.grid
 local brightness_handler = config.brightness_handler
 local device_name = config.device_name

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -32,6 +32,7 @@ local grid_notes = config.grid_notes
 local brightness_handler = config.brightness_handler
 local device_name = config.device_name
 local og_dev_add, og_dev_remove
+local caps = config.caps
 
 -- adding midi device call backs---
 local midigrid = {midi_id = nil}
@@ -193,9 +194,16 @@ function midigrid:led(col, row, brightness)
         if midigrid.device then
             note = grid_notes[row][col]
             if note then
-                table.insert(midigrid.led_buf, 0x90)
-                table.insert(midigrid.led_buf, note)
-                table.insert(midigrid.led_buf, vel)
+                if caps['sysex'] and caps['rgb'] then
+                    sysex = config:led_sysex(note, vel)
+                    for _, byte in ipairs(sysex) do
+                        table.insert(midigrid.led_buf, byte)
+                    end
+                else
+                    table.insert(midigrid.led_buf, 0x90)
+                    table.insert(midigrid.led_buf, note)
+                    table.insert(midigrid.led_buf, vel)
+                end
             else
                 print('no note found! coordinates... x: ' .. col .. ' y: ' .. row .. ' z: ' .. brightness)
             end

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -1,36 +1,29 @@
--- [[--
+--[[ cheapskate lib for getting midi grid devices to behave like monome grid devices
+     local midigrid ={}
+     two things are run before returning, 'setup_connect_handling' and 'update_devices'
+     setup_connect_handling copies over 'og' midi add and remove callbacks, and gives its own
+     add and remove handlers, which means the call backs for
+     add and remove handlers:
+     update devices:
+     find_midi_devices: iterates through 'midi.devices' to see if the name matches, then
+     returns id, this system manages its own ids, which is why you have to initialize it and
+     why
+     first, you connect to it, 'midigrid.connect', which returns a midigrid object and does
+     'set_midi_handler'
+]]
 
--- cheapskate lib for getting midi grid devices to behave like monome grid devices
---   --]]
--- local midigrid ={}
---two things are run before returning, 'setup_connect_handling' and 'update_devices'
---setup_connect_handling copies over 'og' midi add and remove callbacks, and gives its own add and remove handlers, which means the call backs for 
---add and remove handlers:
---update devices:
---find_midi_devices: iterates through 'midi.devices' to see if the name matches, then returns id, this system manages its own ids, which is why you have to initialize it and why
---first, you connect to it, 'midigrid.connect', which returns a midigrid object and does 'set_midi_handler'
---
------------------------------
---loading up config file here
------------------------------
+-- loading up config file here
 local config = include('midigrid/config/apcmini_config')
 -- local config = include('midigrid/config/launchpad_config')
 -- local config = include('midigrid/config/untz_config')
------------------------------
------------------------------
------------------------------
-
 local gridnotes = config.grid
 local brightness_handler = config.brightness_handler
 local device_name = config.device_name
------------------------------
---adding midi device call backs
---------------------------------
-local midigrid= {
-  midi_id = nil
-}
 
+-- adding midi device call backs---
+local midigrid = {midi_id = nil}
 local og_dev_add, og_dev_remove
+
 
 function midigrid.find_midi_device_id()
     local found_id = nil
@@ -43,33 +36,35 @@ function midigrid.find_midi_device_id()
     return found_id
 end
 
+
 function midigrid.connect(dummy_id)
     midigrid.set_midi_handler()
     return midigrid
 end
+
 
 -- function midigrid.set_key_handler(key_handler)
 --     midigrid.set_midi_handler()
 --     midigrid.key = key_handler
 -- end
 
+
 function midigrid.setup_connect_handling()
     og_dev_add = midi.add
     og_dev_remove = midi.remove
-
     midi.add = midigrid.handle_dev_add
     midi.remove = midigrid.handle_dev_remove
 end
+
 
 function midigrid.name_matches(name)
     return (name == device_name)
 end
 
+
 function midigrid.handle_dev_add(id, name, dev)
     og_dev_add(id, name, dev)
-
     midigrid.update_devices()
-
     if (midigrid.name_matches(name)) and (id ~= midigrid.midi_id) then
         midigrid.midi_id = id
         midigrid.device = dev
@@ -77,124 +72,129 @@ function midigrid.handle_dev_add(id, name, dev)
     end
 end
 
+
 function midigrid.handle_dev_remove(id)
     og_dev_remove(id)
     midigrid.update_devices()
 end
 
---this already expects it to have Midi_id
-function midigrid.set_midi_handler()
-    if midigrid.midi_id == nil then
-        return
-    end
 
+-- this already expects it to have Midi_id
+function midigrid.set_midi_handler()
+    if midigrid.midi_id == nil then return end
     if midi.devices[midigrid.midi_id] ~= nil then
         midi.devices[midigrid.midi_id].event = midigrid.handle_key_midi
-        --need this for checking .device
-        midigrid.device=midi.devices[midigrid.midi_id]
+
+        -- need this for checking .device
+        midigrid.device = midi.devices[midigrid.midi_id]
     else
         midigrid.midi_id = nil
     end
 end
 
+
 function midigrid.cleanup()
-  midigrid.key = nil
+    midigrid.key = nil
 end
+
 
 function midigrid.update_devices()
-  midi.update_devices()
+    midi.update_devices()
+    local new_id = midigrid.find_midi_device_id()
 
-  local new_id = midigrid.find_midi_device_id()
-
-  -- Only set id/handler when helpful
-  if (midigrid.midi_id ~= new_id) and (new_id ~= nil) then
-    midigrid.midi_id = new_id
-    return midigrid.set_midi_handler()
-  end
-
-  return (midigrid.midi_id ~= nil)
+    -- Only set id/handler when helpful
+    if (midigrid.midi_id ~= new_id) and (new_id ~= nil) then
+        midigrid.midi_id = new_id
+        return midigrid.set_midi_handler()
+    end
+    return (midigrid.midi_id ~= nil)
 end
 
 
-
---here, using the grid from the config file, we generate the table to help us go the other way around
---so, if you press a midi note and you wanna know what it is, this will have an index with our coordinates
-local note2coords={}
-
-for i,v in ipairs(gridnotes) do
-  for j,k in ipairs(v) do
-    note2coords[k]={j,i}
-  end
+-- here, using the grid from the config file, we generate the table to help us go the other
+-- way around so, if you press a midi note and you wanna know what it is, this will have an
+-- index with our coordinates
+local note2coords = {}
+for i, v in ipairs(gridnotes) do
+    for j, k in ipairs(v) do
+        note2coords[k] = {j, i}
+    end
 end
-
-midigrid.ledbuf={}
-
+midigrid.ledbuf = {}
 midigrid.rows = #gridnotes[1]
 midigrid.cols = #gridnotes
 
+
 function midigrid.handle_key_midi(event)
-  --block cc messages, so they can be mapped
-  if(event[1]==0x90 or event[1]==0x80) then
-    local note = event[2]
-    local coords = note2coords[note]
-    local x, y
-    if coords then
-      x, y = coords[1],coords[2]
-      local s = event[1] ==0x90 and 1 or 0
-      if midigrid.key ~= nil then
-        midigrid.key(x, y, s)
-      end
-    else
-      print("missing coords!")
+    -- block cc messages, so they can be mapped
+    if (event[1] == 0x90 or event[1] == 0x80) then
+        local note = event[2]
+        local coords = note2coords[note]
+        local x, y
+        if coords then
+            x, y = coords[1], coords[2]
+            local s = event[1] == 0x90 and 1 or 0
+            if midigrid.key ~= nil then
+                midigrid.key(x, y, s)
+            end
+        else
+            print("missing coords!")
+        end
     end
-  end
 end
 
 
 function midigrid:led(x, y, z)
-  if self.device then
-    chan = 1
-    --flag reversed here because thats actually what it is in lua table!!!, see above. this is clearer either way I think
-    note = ((x<9 and x>0) and (y<9 and y>0)) and gridnotes[y][x] or null
-    vel = brightness_handler(z)
-    if note then
-      table.insert(self.ledbuf,0x90)
-      table.insert(self.ledbuf,note)
-      table.insert(self.ledbuf,vel)
-    else
-      --debugger, probably want to comment this out if you are being messyy
-      print("no note found! coordinates....  x:"..x.."  y:"..y.."  z:"..z)
+    if self.device then
+        chan = 1
+
+        -- flag reversed here because thats actually what it is in lua table!!!, see above.
+        -- this is clearer either way I think
+        note = ((x < 9 and x > 0) and (y < 9 and y > 0)) and gridnotes[y][x] or nil
+        vel = brightness_handler(z)
+        if note then
+            table.insert(self.ledbuf, 0x90)
+            table.insert(self.ledbuf, note)
+            table.insert(self.ledbuf, vel)
+        else
+
+            -- debugger, probably want to comment this out if you are being messyy
+            print("no note found! coordinates....  x:" .. x .. "  y:" .. y ..
+                      "  z:" .. z)
+        end
     end
-  end
 end
 
 
---sending our buff
+-- sending our buff
 function midigrid:refresh()
-  if self.device then
-    -- self:send(self.ledbuf)
-    midi.devices[midigrid.midi_id]:send(self.ledbuf)
-    self.ledbuf={}
-  end
+    if self.device then
+        -- self:send(self.ledbuf)
+        midi.devices[midigrid.midi_id]:send(self.ledbuf)
+        self.ledbuf = {}
+    end
 end
+
 
 function midigrid:all(vel)
-  if self.device then
-    self.ledbuf={}
-    for x=1, #gridnotes do
-      for y=1, #gridnotes[x] do
-        chan = 1
-        note = gridnotes[x][y]
-        vel = brightness_handler(vel)
-        table.insert(self.ledbuf,0x90)
-        table.insert(self.ledbuf,note)
-        table.insert(self.ledbuf,vel)
-      end
-      -- it is unclear to me sometimes if a call to all in a regular grid requires a subsequent refresh, have this here in case
-      -- self:refresh()
+    if self.device then
+        self.ledbuf = {}
+        for x = 1, #gridnotes do
+            for y = 1, #gridnotes[x] do
+                chan = 1
+                note = gridnotes[x][y]
+                vel = brightness_handler(vel)
+                table.insert(self.ledbuf, 0x90)
+                table.insert(self.ledbuf, note)
+                table.insert(self.ledbuf, vel)
+            end
+            -- it is unclear to me sometimes if a call to all in a regular grid requires a
+            -- subsequent refresh, have this here in cqase
+            -- self:refresh()
+        end
     end
-  end
 end
+
 
 -- setting up connection and connection callbacks before returning
 midigrid.setup_connect_handling()

--- a/lib/midigrid_2pages.lua
+++ b/lib/midigrid_2pages.lua
@@ -3,10 +3,23 @@
      the 'leftpage'/'rightpage' buttons as defined in the relevant config file.
 ]]
 
---  loading up config file here
-local config = include('midigrid/config/apcmini_config')
--- local config = include('midigrid/config/launchpad_config')
-
+local supported_devices = {apcmini = 'apcmini',
+                           launchpadmk2 = 'launchpad mk2',
+                           launchpadpro = 'launchpad pro 2',
+                           launchpad = 'launchpad'}
+local config_name = 'none'
+for _, dev in pairs(midi.devices) do
+    local name = string.lower(dev.name)
+    for device, device_name in pairs(supported_devices) do
+        if name == device_name then
+            config_name = 'midigrid/config/' .. device .. '_config'
+        end
+    end
+end
+if config_name == 'none' then
+    print('No supported device found')
+end
+local config = include(config_name)
 local gridnotes = config.grid
 local brightness_handler = config.brightness_handler
 local device_name = config.device_name

--- a/lib/midigrid_2pages.lua
+++ b/lib/midigrid_2pages.lua
@@ -1,49 +1,37 @@
--- [[--
---  cheapskate library for apc, 2 pages
---  contains within itself a full 128 grid table, that can be viewed and played with by changing the two buttons at the bottom of the apc
--- --]]
+--[[ cheapskate library for apc, 2 pages contains within itself a full 128 grid table, that
+     can be viewed and played with by changing the two buttons at the bottom of the apc
+]]
 
------------------------------
---loading up config file here
------------------------------
+--  loading up config file here
 local config = include('midigrid/config/apcmini_config')
 -- local config = include('midigrid/config/launchpad_config')
------------------------------
------------------------------
------------------------------
 
+-- start on "page" 1
+local apcpage = 1
 
-
-
-
---start on "page" 1
-local apcpage=1
-
---make the grid buf
-local gridbuf={}
-for i=1,16 do
-  gridbuf[i]={}
-  for j=1,8 do
-    gridbuf[i][j]=0
-  end
+-- make the grid buf
+local gridbuf = {}
+for i = 1, 16 do
+    gridbuf[i] = {}
+    for j = 1, 8 do
+        gridbuf[i][j] = 0
+    end
 end
 
 local gridnotes = config.grid
 local brightness_handler = config.brightness_handler
 local device_name = config.device_name
---set your left right page numbers here...
+
+-- set your left right page numbers here...
 -- local leftpage = config.auxrow[3]
 local leftpage = config.leftpage_button
 local rightpage = config.rightpage_button
 -- local rightpage = config.auxrow[4]
------------------------------
---adding midi device call backs
---------------------------------
-local midigrid= {
-  midi_id = nil
-}
 
+-- adding midi device call backs
+local midigrid = {midi_id = nil}
 local og_dev_add, og_dev_remove
+
 
 function midigrid.find_midi_device_id()
     local found_id = nil
@@ -56,35 +44,37 @@ function midigrid.find_midi_device_id()
     return found_id
 end
 
+
 function midigrid.connect(dummy_id)
     midigrid.set_midi_handler()
-    midi.devices[midigrid.midi_id]:send({144,leftpage,1})
-    midi.devices[midigrid.midi_id]:send({144,rightpage,0})
+    midi.devices[midigrid.midi_id]:send({144, leftpage, 1})
+    midi.devices[midigrid.midi_id]:send({144, rightpage, 0})
     return midigrid
 end
+
 
 -- function midigrid.set_key_handler(key_handler)
 --     midigrid.set_midi_handler()
 --     midigrid.key = key_handler
 -- end
 
+
 function midigrid.setup_connect_handling()
     og_dev_add = midi.add
     og_dev_remove = midi.remove
-
     midi.add = midigrid.handle_dev_add
     midi.remove = midigrid.handle_dev_remove
 end
+
 
 function midigrid.name_matches(name)
     return (name == device_name)
 end
 
+
 function midigrid.handle_dev_add(id, name, dev)
     og_dev_add(id, name, dev)
-
     midigrid.update_devices()
-
     if (midigrid.name_matches(name)) and (id ~= midigrid.midi_id) then
         midigrid.midi_id = id
         midigrid.device = dev
@@ -92,230 +82,232 @@ function midigrid.handle_dev_add(id, name, dev)
     end
 end
 
+
 function midigrid.handle_dev_remove(id)
     og_dev_remove(id)
     midigrid.update_devices()
 end
 
---this already expects it to have Midi_id
-function midigrid.set_midi_handler()
-    if midigrid.midi_id == nil then
-        return
-    end
 
+-- this already expects it to have Midi_id
+function midigrid.set_midi_handler()
+    if midigrid.midi_id == nil then return end
     if midi.devices[midigrid.midi_id] ~= nil then
         midi.devices[midigrid.midi_id].event = midigrid.handle_key_midi
-        --need this for checking .device
-        midigrid.device=midi.devices[midigrid.midi_id]
+
+        -- need this for checking .device
+        midigrid.device = midi.devices[midigrid.midi_id]
     else
         midigrid.midi_id = nil
     end
 end
 
-function midigrid.cleanup()
-  midigrid.key = nil
-end
+
+function midigrid.cleanup() midigrid.key = nil end
+
 
 function midigrid.update_devices()
-  midi.update_devices()
+    midi.update_devices()
+    local new_id = midigrid.find_midi_device_id()
 
-  local new_id = midigrid.find_midi_device_id()
-
-  -- Only set id/handler when helpful
-  if (midigrid.midi_id ~= new_id) and (new_id ~= nil) then
-    midigrid.midi_id = new_id
-    return midigrid.set_midi_handler()
-  end
-
-  return (midigrid.midi_id ~= nil)
+    -- Only set id/handler when helpful
+    if (midigrid.midi_id ~= new_id) and (new_id ~= nil) then
+        midigrid.midi_id = new_id
+        return midigrid.set_midi_handler()
+    end
+    return (midigrid.midi_id ~= nil)
 end
 
-aliascoords_event={}
-aliascoords_led={}
-function midigrid.make_alias(note,x,y)
-  aliascoords_event[note]={x,y}
-  aliascoords_led[x+(y*8)]=note
-end
-function midigrid.check_alias_event(note,noteon)
-  if aliascoords_event[note] then
-    local x = aliascoords_event[note][1]
-    local y = aliascoords_event[note][2]
-    local s = noteon ==0x90 and 1 or 0
-    midigrid.key(x,y,s)
-  end
-end
-function midigrid.check_alias_led(x,y,z)
-  if aliascoords_led[x+(y*8)] then
-      table.insert(midigrid.ledbuf,0x90)
-      table.insert(midigrid.ledbuf,aliascoords_led[x+(y*8)])
-      local vel = z ==0 and 0 or 1
-      table.insert(midigrid.ledbuf,vel)
-      -- print('led call',x,y,z)
-  end
+
+aliascoords_event = {}
+aliascoords_led = {}
+function midigrid.make_alias(note, x, y)
+    aliascoords_event[note] = {x, y}
+    aliascoords_led[x + (y * 8)] = note
 end
 
---getting the two pages set up
-apcnotecoords1={}
-apcnotecoords2={}
-for i,v in ipairs(gridnotes) do
-  for j,k in ipairs(v) do
-    apcnotecoords1[k]={j,i}
-  end
+
+function midigrid.check_alias_event(note, noteon)
+    if aliascoords_event[note] then
+        local x = aliascoords_event[note][1]
+        local y = aliascoords_event[note][2]
+        local s = noteon == 0x90 and 1 or 0
+        midigrid.key(x, y, s)
+    end
 end
 
-for i,v in ipairs(gridnotes) do
-  for j,k in ipairs(v) do
-    apcnotecoords2[k]={j+8,i}
-  end
+
+function midigrid.check_alias_led(x, y, z)
+    if aliascoords_led[x + (y * 8)] then
+        table.insert(midigrid.ledbuf, 0x90)
+        table.insert(midigrid.ledbuf, aliascoords_led[x + (y * 8)])
+        local vel = z == 0 and 0 or 1
+        table.insert(midigrid.ledbuf, vel)
+        -- print('led call',x,y,z)
+    end
 end
-apcnotecoords = {apcnotecoords1,apcnotecoords2}
 
 
-midigrid.ledbuf={}
-
+-- getting the two pages set up
+apcnotecoords1 = {}
+apcnotecoords2 = {}
+for i, v in ipairs(gridnotes) do
+    for j, k in ipairs(v) do
+        apcnotecoords1[k] = {j, i}
+    end
+end
+for i, v in ipairs(gridnotes) do
+    for j, k in ipairs(v) do
+        apcnotecoords2[k] = {j + 8, i}
+    end
+end
+apcnotecoords = {apcnotecoords1, apcnotecoords2}
+midigrid.ledbuf = {}
 midigrid.rows = #gridnotes[1]
 midigrid.cols = #gridnotes
 
 
-function midigrid:led(x, y, z) 
-  midigrid.check_alias_led(x,y,z)
-  if x < 17 and y<9 and x >0 and y >0 then
+function midigrid:led(x, y, z)
+    midigrid.check_alias_led(x, y, z)
+    if x < 17 and y < 9 and x > 0 and y > 0 then
+        vel = brightness_handler(z)
+        gridbuf[x][y] = z
 
-    vel = brightness_handler(z)
-    gridbuf[x][y]=z
-    --if we aint on the right page dont bother
-    if x>8 and apcpage==1 then
-      return
+        -- if we aint on the right page dont bother
+        if x > 8 and apcpage == 1 then
+            return
+        end
+        if x < 8 and apcpage == 2 then
+            return
+        end
+        if self.device then
+            chan = 1
+            if apcpage == 1 then
+                note = gridnotes[y][x]
+            elseif apcpage == 2 then
+                note = gridnotes[y][x - 8]
+            end
+            if note then
+                table.insert(self.ledbuf, 0x90)
+                table.insert(self.ledbuf, note)
+                table.insert(self.ledbuf, vel)
+                -- print('led call',x,y,z)
+            else
+
+                -- debugger
+                print(
+                    "no note found! coordinates....  x:" .. x .. "  y:" .. y .. "  z:" .. z)
+            end
+        end
     end
-    if x<8 and apcpage==2 then
-      return
-    end
-
-    if self.device then
-      chan = 1
-
-      if apcpage==1 then
-        note = gridnotes[y][x] 
-      elseif apcpage==2 then
-        note = gridnotes[y][x-8]
-      end
-
-      if note then
-        table.insert(self.ledbuf,0x90)
-        table.insert(self.ledbuf,note)
-        table.insert(self.ledbuf,vel)
-        -- print('led call',x,y,z)
-      else
-        --debugger
-        print("no note found! coordinates....  x:"..x.."  y:"..y.."  z:"..z)
-      end
-    end
-  end
 end
+
 
 -- sure there is more elegant way!
 function midigrid:changepage(page)
-  midigrid.ledbuf={}
-  -- self:all(4)
-  if page==1 then
-    for i=1,8 do
-      for j=1,8 do
-        midigrid:led(i,j,gridbuf[i][j])
-      end
+    midigrid.ledbuf = {}
+    -- self:all(4)
+    if page == 1 then
+        for i = 1, 8 do
+            for j = 1, 8 do
+                midigrid:led(i, j, gridbuf[i][j])
+            end
+        end
+    elseif page == 2 then
+        for i = 9, 16 do
+            for j = 1, 8 do
+                -- print('page2',gridbuf[i][j])
+                midigrid:led(i, j, gridbuf[i][j])
+            end
+        end
     end
-  elseif page==2 then
-    for i=9,16 do
-      for j=1,8 do
-        -- print('page2',gridbuf[i][j])
-        midigrid:led(i,j,gridbuf[i][j])
-      end
-    end
-  end
-  midigrid:refresh()
+    midigrid:refresh()
 end
-
 
 
 function midigrid.handle_key_midi(data)
-  note = data[2]
-  midigrid.check_alias_event(data[2],data[1])
-  --first, intercept page selectors
-  if note==leftpage or note==rightpage then
-    if note==leftpage and data[1]==0x90 and apcpage ~= 1 then
-      apcpage=1
-      -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=rightpage,vel=0})
-      midi.devices[midigrid.midi_id]:send({144,rightpage,0})
-      midi.devices[midigrid.midi_id]:send({144,leftpage,1})
-      -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=leftpage,vel=1})
-      midigrid:changepage(apcpage)
-    elseif note==rightpage and data[1]==0x90 and apcpage ~= 2  then
-      apcpage=2
-      -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=leftpage,vel=0})
-      -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=rightpage,vel=1})
-      midi.devices[midigrid.midi_id]:send({144,rightpage,1})
-      midi.devices[midigrid.midi_id]:send({144,leftpage,0})
-      midigrid:changepage(apcpage)
-    end
-  elseif note > -1 and note < 64 then
-    local coords = apcnotecoords[apcpage][note]
-    local x, y
-    if coords then
-      x, y = coords[1],coords[2] 
-      local s = data[1] ==0x90 and 1 or 0
-      midigrid.key(x,y,s)
+    note = data[2]
+    midigrid.check_alias_event(data[2], data[1])
+
+    -- first, intercept page selectors
+    if note == leftpage or note == rightpage then
+        if note == leftpage and data[1] == 0x90 and apcpage ~= 1 then
+            apcpage = 1
+            -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=rightpage,vel=0})
+            midi.devices[midigrid.midi_id]:send({144, rightpage, 0})
+            midi.devices[midigrid.midi_id]:send({144, leftpage, 1})
+            -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=leftpage,vel=1})
+            midigrid:changepage(apcpage)
+        elseif note == rightpage and data[1] == 0x90 and apcpage ~= 2 then
+            apcpage = 2
+            -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=leftpage,vel=0})
+            -- midi.devices[midigrid.midi_id]:send({type="note_on",ch=1,note=rightpage,vel=1})
+            midi.devices[midigrid.midi_id]:send({144, rightpage, 1})
+            midi.devices[midigrid.midi_id]:send({144, leftpage, 0})
+            midigrid:changepage(apcpage)
+        end
+    elseif note > -1 and note < 64 then
+        local coords = apcnotecoords[apcpage][note]
+        local x, y
+        if coords then
+            x, y = coords[1], coords[2]
+            local s = data[1] == 0x90 and 1 or 0
+            midigrid.key(x, y, s)
+        else
+            local coords = apcnotecoords[apcpage][note]
+            local x, y
+            print("missing coords!", x, y, s)
+        end
     else
-      local coords = apcnotecoords[apcpage][note]
-      local x, y
-      print("missing coords!",x,y,s)
+        print("unmapped key")
     end
-  else
-    print("unmapped key")
-  end
 end
 
-function midigrid:refresh() 
-  if self.device then
-    -- self:send(self.ledbuf)
-    midi.devices[midigrid.midi_id]:send(self.ledbuf)
-    self.ledbuf={}
-  end
+
+function midigrid:refresh()
+    if self.device then
+        -- self:send(self.ledbuf)
+        midi.devices[midigrid.midi_id]:send(self.ledbuf)
+        self.ledbuf = {}
+    end
 end
+
 
 function midigrid:all(z)
-  vel = brightness_handler(z)
-  if self.device then
-    -- self.ledbuf={}
-    for x=1, 16 do
-      for y=1, 8 do
-        local data
-        local oldvel = gridbuf[x][y]
-        gridbuf[x][y]=z
-        if gridbuf[x][y]~=oldvel then
-          -- gridbuf[x][y]=vel
-          midigrid.check_alias_led(x,y,z)
-          if (apcpage==1 and x<9) then
-            note = gridnotes[y][x] 
-            table.insert(self.ledbuf,0x90)
-            table.insert(self.ledbuf,note)
-            table.insert(self.ledbuf,vel)
-          elseif (apcpage==2 and x>8) then
-            note = gridnotes[y][x-8]
-            table.insert(self.ledbuf,0x90)
-            table.insert(self.ledbuf,note)
-            table.insert(self.ledbuf,vel)
-          end
-          -- print('all call',x,y,vel)
+    vel = brightness_handler(z)
+    if self.device then
+        -- self.ledbuf={}
+        for x = 1, 16 do
+            for y = 1, 8 do
+                local data
+                local oldvel = gridbuf[x][y]
+                gridbuf[x][y] = z
+                if gridbuf[x][y] ~= oldvel then
+                    -- gridbuf[x][y]=vel
+                    midigrid.check_alias_led(x, y, z)
+                    if (apcpage == 1 and x < 9) then
+                        note = gridnotes[y][x]
+                        table.insert(self.ledbuf, 0x90)
+                        table.insert(self.ledbuf, note)
+                        table.insert(self.ledbuf, vel)
+                    elseif (apcpage == 2 and x > 8) then
+                        note = gridnotes[y][x - 8]
+                        table.insert(self.ledbuf, 0x90)
+                        table.insert(self.ledbuf, note)
+                        table.insert(self.ledbuf, vel)
+                    end
+                    -- print('all call',x,y,vel)
+                end
+            end
+            -- if this is needed
+            -- midi.devices[midigrid.midi_id]:send(self.ledbuf)
+            -- self.ledbuf={}
         end
-      end
-      -- if this is needed
-      -- midi.devices[midigrid.midi_id]:send(self.ledbuf)
-      -- self.ledbuf={}
     end
-  end
 end
---init on page 1
+
+-- init on page 1
 midigrid.setup_connect_handling()
 midigrid.update_devices()
-
 
 return midigrid

--- a/lib/midigrid_2pages.lua
+++ b/lib/midigrid_2pages.lua
@@ -159,9 +159,8 @@ function midigrid:all(brightness)
     if midigrid.device then
         for row = 1, midigrid.rows do
             for col = 1, midigrid.cols do
-                local oldvel = grid_buf[row][col]
-                grid_buf[row][col] = brightness
-                if grid_buf[row][col] ~= oldvel then    -- this led needs to be set
+                if grid_buf[row][col] ~= brightness then  -- this led needs to be set
+                    grid_buf[row][col] = brightness
                     if (page == 1 and col < 9) then
                         note = grid_notes[row][col]
                         table.insert(midigrid.led_buf, 0x90)
@@ -188,10 +187,10 @@ function midigrid:led(col, row, brightness)
         grid_buf[row][col] = brightness
 
         -- if we aint on the right page dont bother
-        if col > 8 and page == 1 then
+        if col >= 9 and page == 1 then
             return
         end
-        if col < 8 and page == 2 then
+        if col <= 8 and page == 2 then
             return
         end
         if midigrid.device then

--- a/lib/midigrid_2pages.lua
+++ b/lib/midigrid_2pages.lua
@@ -186,9 +186,6 @@ function midigrid:all(brightness)
                             table.insert(midigrid.led_buf, note)
                             table.insert(midigrid.led_buf, vel)
                         end
-                        table.insert(midigrid.led_buf, 0x90)
-                        table.insert(midigrid.led_buf, note)
-                        table.insert(midigrid.led_buf, vel)
                     end
                 end
             end


### PR DESCRIPTION
@miker2049 - PTAL!  I started out wanting to support the LP Pro, and ended up doing a lot more :P

I'd suggest reviewing commit-by-commit, as the final diffs are too different to reason about easily.

I'm a Pythonista by trade and by calling, so I have to tell you that learning Lua has been PAINFUL. I tried to avoid making changes just for the sake of making changes, or to look at it another way, I only made changes which I felt would help (me and others) when trying to reason about the data structures and logic herein.

I could only test with my LP Pro - I have no other devices. OTOH e.g. Loom is a pretty complex script, grid-display-wise, and works *perfectly*, so I feel pretty good about this PR, ie. that it should work OOB for other devices.

Changes which aren't strictly for the LP Pro:
-  it *should* be easier to add new devices (create config file, add an entry to the `supported_devices` table in midigrid/midigrid_2pages
- code paths are in place to work with sysex and CCs
- midigrid and midigrid_2pages are enough alike now that it should be easy (for someone with more Lua-fu than me) to refactor the whole business into e.g. 'midigrid.lua', 'mg_64', 'mg_128', and yes, even 'mg_256' (I might try this myself, after I take a break :), where 'midigrid.lua' contains common code.