### PR TITLE
Enable double buffering on Launchpad and Launchpad Mini grids.

### DIFF
--- a/config/launchpadmini_config.lua
+++ b/config/launchpadmini_config.lua
@@ -47,7 +47,7 @@ local launchpad={
   auxcol = {8,24,40,56,72,88,104,120},
   --need to impletement launchpad row, they are 176 messages instead, which messes stuff up right now
   auxrow = {},
-
+  
   -- table of device-specific capabilities
     caps = {
       -- can we use sysex to update the grid leds?
@@ -81,7 +81,7 @@ local launchpad={
     end
   end,
 
-  device_name='launchpad'
+  device_name='launchpad mini'
 }
 
 return launchpad

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -14,7 +14,9 @@
 local supported_devices = {apcmini = 'apcmini',
                            launchpadmk2 = 'launchpad mk2',
                            launchpadpro = 'launchpad pro 2',
-                           launchpad = 'launchpad'}
+                           launchpad = 'launchpad',
+                           launchpadmini = 'launchpad mini'
+}
 local config_name = 'none'
 for _, dev in pairs(midi.devices) do
     local name = string.lower(dev.name)
@@ -215,6 +217,11 @@ end
 -- ...then we send the whole buf at once
 function midigrid:refresh()
     if midigrid.device then
+      
+        if caps['lp_double_buffer'] then
+          midi.devices[midigrid.midi_id]:send(config:display_double_buffer_sysex())
+        end
+        
         midi.devices[midigrid.midi_id]:send(midigrid.led_buf)
 
         -- ...and clear the buffer again.

--- a/lib/midigrid_2pages.lua
+++ b/lib/midigrid_2pages.lua
@@ -6,7 +6,10 @@
 local supported_devices = {apcmini = 'apcmini',
                            launchpadmk2 = 'launchpad mk2',
                            launchpadpro = 'launchpad pro 2',
-                           launchpad = 'launchpad'}
+                           launchpad = 'launchpad',
+                           launchpadmini = 'launchpad mini'
+  
+}
 local config_name = 'none'
 for _, dev in pairs(midi.devices) do
     local name = string.lower(dev.name)
@@ -237,6 +240,11 @@ end
 function midigrid:refresh()
     local local_grid = midi.devices[midigrid.midi_id]
     if midigrid.device then
+      
+        if caps['lp_double_buffer'] then
+          midi.devices[midigrid.midi_id]:send(config:display_double_buffer_sysex())
+        end
+      
         local_grid:send(midigrid.led_buf)
 
         -- apparently, we need to refresh the page leds as well


### PR DESCRIPTION
This should reduce flickering on grid update. Tested with Awake on Launchpad mini only.

Creates a launchpad mini config that is almost identical to the launchpad config. Not ideal, but best I could do without a refactor of the midi grid device detection that I don't think my lua skills are up to yet.