### PR TITLE
Implement 4-quad ("256") mode...

### DIFF
--- a/config/apcmini_config.lua
+++ b/config/apcmini_config.lua
@@ -32,9 +32,12 @@ local apcmini={
   --left to right, 64 is aux key to column 1
   auxrow = {64,65,66,67,68,69,70,71},
 
-  -- here is setting the left and right page buttons for two page mode
-  leftpage_button=66,
-  rightpage_button=67,
+  -- here we set the buttons to use when switching quads in multi-quad mode
+  upper_left_quad_button = 66,
+  upper_right_quad_button = 67,
+  -- TODO: contributors with this device - please fill this in
+  -- lower_left_quad_button = ??,
+  -- lower_right_quad_button = ??,
 
   device_name='apc mini'
 }

--- a/config/launchpad_config.lua
+++ b/config/launchpad_config.lua
@@ -65,9 +65,8 @@ local launchpad={
   -- here we set the buttons to use when switching quads in multi-quad mode
   upper_left_quad_button = 8,
   upper_right_quad_button = 24,
-  -- TODO: contributors with this device - please fill this in
-  -- lower_left_quad_button = ??,
-  -- lower_right_quad_button = ??,
+  lower_left_quad_button = 40,
+  lower_right_quad_button = 56,
 
   -- somewhere to keep track of current displayed buffer in double buffer mode
   current_double_buffer = 0,

--- a/config/launchpad_config.lua
+++ b/config/launchpad_config.lua
@@ -51,7 +51,7 @@ local launchpad={
   -- table of device-specific capabilities
     caps = {
       -- can we use sysex to update the grid leds?
-      -- TODO on the launchpad we could use sysex to fast update all leds at refresh. 
+      -- TODO on the launchpad we could use sysex to fast update all leds at refresh.
       -- This would require a custom midigred led and refreash methods as 2 leds are written at once!
       sysex = false,
       -- is this an rgb device?
@@ -62,13 +62,16 @@ local launchpad={
       cc_edge_buttons = true
     },
 
-  -- here is setting the left and right page buttons for two page mode
-  leftpage_button=8,
-  rightpage_button=24,
-  
+  -- here we set the buttons to use when switching quads in multi-quad mode
+  upper_left_quad_button = 8,
+  upper_right_quad_button = 24,
+  -- TODO: contributors with this device - please fill this in
+  -- lower_left_quad_button = ??,
+  -- lower_right_quad_button = ??,
+
   -- somewhere to keep track of current displayed buffer in double buffer mode
   current_double_buffer = 0,
-  
+
   display_double_buffer_sysex = function(self)
     if (self.current_display_buffer == 0) then
       self.current_display_buffer = 1

--- a/config/launchpadmini_config.lua
+++ b/config/launchpadmini_config.lua
@@ -65,9 +65,8 @@ local launchpad={
   -- here we set the buttons to use when switching quads in multi-quad mode
   upper_left_quad_button = 8,
   upper_right_quad_button = 24,
-  -- TODO: contributors with this device - please fill this in
-  -- lower_left_quad_button = ??,
-  -- lower_right_quad_button = ??,
+  lower_left_quad_button = 40,
+  lower_right_quad_button = 56,
 
   -- somewhere to keep track of current displayed buffer in double buffer mode
   current_double_buffer = 0,

--- a/config/launchpadmini_config.lua
+++ b/config/launchpadmini_config.lua
@@ -47,11 +47,11 @@ local launchpad={
   auxcol = {8,24,40,56,72,88,104,120},
   --need to impletement launchpad row, they are 176 messages instead, which messes stuff up right now
   auxrow = {},
-  
+
   -- table of device-specific capabilities
     caps = {
       -- can we use sysex to update the grid leds?
-      -- TODO on the launchpad we could use sysex to fast update all leds at refresh. 
+      -- TODO on the launchpad we could use sysex to fast update all leds at refresh.
       -- This would require a custom midigred led and refreash methods as 2 leds are written at once!
       sysex = false,
       -- is this an rgb device?
@@ -62,13 +62,16 @@ local launchpad={
       cc_edge_buttons = true
     },
 
-  -- here is setting the left and right page buttons for two page mode
-  leftpage_button=8,
-  rightpage_button=24,
-  
+  -- here we set the buttons to use when switching quads in multi-quad mode
+  upper_left_quad_button = 8,
+  upper_right_quad_button = 24,
+  -- TODO: contributors with this device - please fill this in
+  -- lower_left_quad_button = ??,
+  -- lower_right_quad_button = ??,
+
   -- somewhere to keep track of current displayed buffer in double buffer mode
   current_double_buffer = 0,
-  
+
   display_double_buffer_sysex = function(self)
     if (self.current_display_buffer == 0) then
       self.current_display_buffer = 1

--- a/config/launchpadmk2_config.lua
+++ b/config/launchpadmk2_config.lua
@@ -52,10 +52,13 @@ local launchpad = {
   -- top to bottom
   -- right side
   auxcol = {89, 79, 69, 59, 49, 39, 29, 19},
-  -- here we set the left and right page buttons for two page mode
-  -- we can simply use the cc # as-is
-  leftpage_button = 89,
-  rightpage_button = 79,
+
+  -- here we set the buttons to use when switching quads in multi-quad mode
+  upper_left_quad_button = 89,
+  upper_right_quad_button = 79,
+  -- TODO: contributors with this device - please fill this in
+  -- lower_left_quad_button = ??,
+  -- lower_right_quad_button = ??,
 
   -- table of device-specific capabilities
   caps = {

--- a/config/launchpadpro_config.lua
+++ b/config/launchpadpro_config.lua
@@ -1,6 +1,10 @@
 --[[ Launchpad Pro's Programmer ("orange") mode is *required* for this to work.
      No other setup should be necessary, on either the LP or the norns/fates side.
 ]]
+<<<<<<< HEAD
+=======
+
+>>>>>>> 36acf2f... Implement 4-quad ("256") mode. This requires a little bit of refactoring for "2-page" mode, and the various device config files
 local launchpad = {
     -- here we have the 'grid'. this looks literally like the grid notes as they are on
     -- the device.
@@ -63,19 +67,23 @@ local launchpad = {
     -- bottom
     auxrow2 = {1, 2, 3, 4, 5, 6, 7, 8},
 
-    -- here we set the left and right page buttons for two page mode
+    -- here we set the buttons to use when switching quads in multi-quad mode
     -- we can simply use the cc # as-is
-    leftpage_button = 93,
-    rightpage_button = 94,
+    upper_left_quad_button = 91,
+    upper_right_quad_button = 92,
+    lower_left_quad_button = 93,
+    lower_right_quad_button = 94,
 
     -- table of device-specific capabilities
     caps = {
-      -- can we use sysex to update the grid leds?
-      sysex = true,
-      -- is this an rgb device?
-      rgb = true,
-      -- do the edge buttons send cc?
-      cc_edge_buttons = true
+        -- can we use sysex to update the grid leds?
+        sysex = true,
+        -- is this an rgb device?
+        rgb = true,
+        -- can we double buffer?
+        lp_double_buffer = false,
+        -- do the edge buttons send cc?
+        cc_edge_buttons = true
     },
 
 
@@ -112,7 +120,6 @@ local launchpad = {
         local end_sysex = '0xf7'
         local sysex_str = string.format('0xf0, 0x00, 0x20, 0x29, 0x02, 0x10, %s%s%s',
                                         command, var_args, end_sysex)
-        -- print(sysex_str)
         local sysex = tab.split(sysex_str, ', ')
         return sysex
     end,

--- a/lib/mg_256.lua
+++ b/lib/mg_256.lua
@@ -1,0 +1,458 @@
+--[[ cheapskate library for midi grid devices, 4 quads, i.e. a "256" device.
+     contains within itself a full 256 grid table, which can be viewed and played by pressing
+     the '*_quad_button' buttons as defined in the relevant config file.
+]]
+
+-- if there's no *monome* grid attached, norns returns a valid but unpopulated grid table
+-- so must we
+local midigrid = {
+    midi_id = nil,
+    device = nil,
+    rows = 0,
+    cols = 0,
+    name = "none"
+}
+
+
+brightness_handler = function(val) return 0 end
+
+
+function midigrid.init()
+    local supported_devices = {
+        apcmini = "apcmini",
+        launchpadmk2 = "launchpad mk2",
+        launchpadpro = "launchpad pro 2",
+        launchpad = "launchpad",
+        launchpadmini = "launchpad mini"
+    }
+    local config_name = "none"
+    config = nil
+    for _, dev in pairs(midi.devices) do
+        local name = string.lower(dev.name)
+        for device, device_name in pairs(supported_devices) do
+            if name == device_name then
+                config_name = "midigrid/config/" .. device .. "_config"
+            end
+        end
+    end
+    if config_name == "none" then
+        print("No supported device found")
+        return midigrid
+    end
+    config = include(config_name)
+    grid_notes = config.grid_notes
+    brightness_handler = config.brightness_handler
+    device_name = config.device_name
+    og_dev_add = nil
+    og_dev_remove = nil
+    caps = config.caps
+    upper_left_quad = config.upper_left_quad_button
+    upper_right_quad = config.upper_right_quad_button
+    lower_left_quad = config.lower_left_quad_button
+    lower_right_quad = config.lower_right_quad_button
+
+    -- adding midi device call backs
+    midigrid.led_buf = {}
+    midigrid.rows = #grid_notes[1] * 2  -- an assumption, but a safe one
+    midigrid.cols = #grid_notes * 2  -- as above
+
+    -- start on "quad" 1
+    quad = 1
+
+    -- make the grid buf
+    grid_buf = {}
+    for rows = 1, midigrid.rows do
+        grid_buf[rows] = {}
+        for cols = 1, midigrid.cols do
+            grid_buf[rows][cols] = 0
+        end
+    end
+
+    -- getting the four quads set up
+    local upper_left_note_coords = {}
+    local upper_right_note_coords = {}
+    local lower_left_note_coords = {}
+    local lower_right_note_coords = {}
+    for row, notes in ipairs(grid_notes) do
+        for col, note in ipairs(notes) do
+            upper_left_note_coords[note] = {col, row}
+            upper_right_note_coords[note] = {col + 8, row}
+            lower_left_note_coords[note] = {col, row + 8}
+            lower_right_note_coords[note] = {col + 8, row + 8}
+        end
+    end
+    note_coords = {
+        upper_left_note_coords,
+        upper_right_note_coords,
+        lower_left_note_coords,
+        lower_right_note_coords
+    }
+
+    -- setting up connection and connection callbacks before returning
+    midigrid.setup_connect_handling()
+    midigrid.update_devices()
+end
+
+
+function midigrid.find_midi_device_id()
+    local found_id = nil
+    for _, dev in pairs(midi.devices) do
+        local name = string.lower(dev.name)
+        if midigrid.name_matches(name) then
+            found_id = dev.id
+        end
+    end
+    return found_id
+end
+
+
+function midigrid.connect(dummy_id)
+    if config == nil then
+        return midigrid
+    end
+    midigrid.set_midi_handler()
+    local local_grid = midi.devices[midigrid.midi_id]
+    print('midigrid "' .. device_name .. '" has ' .. midigrid.rows .. " rows, " .. midigrid.cols .. " cols")
+    midigrid:all(0)
+    midigrid:refresh()
+
+    -- init on page 1
+    local_grid:note_on(upper_left_quad, 1)
+    local_grid:note_on(upper_right_quad, 0)
+    local_grid:note_on(lower_left_quad, 0)
+    local_grid:note_on(lower_right_quad, 0)
+    return midigrid
+end
+
+
+function midigrid.set_key_handler(key_handler)
+    midigrid.set_midi_handler()
+    midigrid.key = key_handler
+end
+
+
+function midigrid.setup_connect_handling()
+    og_dev_add = midi.add
+    og_dev_remove = midi.remove
+    midi.add = midigrid.handle_dev_add
+    midi.remove = midigrid.handle_dev_remove
+end
+
+
+function midigrid.name_matches(name)
+    return (name == device_name)
+end
+
+
+function midigrid.handle_dev_add(id, name, dev)
+    og_dev_add(id, name, dev)
+    midigrid.update_devices()
+    if (midigrid.name_matches(name)) and (id ~= midigrid.midi_id) then
+        midigrid.midi_id = id
+        midigrid.set_midi_handler()
+    end
+end
+
+
+function midigrid.handle_dev_remove(id)
+    og_dev_remove(id)
+    midigrid.update_devices()
+end
+
+
+-- this already expects it to have Midi_id
+function midigrid.set_midi_handler()
+    if midigrid.midi_id == nil then
+        return
+    end
+    if midi.devices[midigrid.midi_id] ~= nil then
+        midi.devices[midigrid.midi_id].event = midigrid.handle_key_midi
+
+        -- need this for checking .device
+        midigrid.device = midi.devices[midigrid.midi_id]
+        print("`midigrid.device` is:")
+        tab.print(midigrid.device)
+    else
+        midigrid.midi_id = nil
+    end
+end
+
+
+function midigrid.cleanup()
+    midigrid.key = nil
+end
+
+
+function midigrid.update_devices()
+    midi.update_devices()
+    local new_id = midigrid.find_midi_device_id()
+
+    -- Only set id/handler when helpful
+    if (new_id ~= nil) and (midigrid.midi_id ~= new_id) then
+        midigrid.midi_id = new_id
+        midigrid.set_midi_handler()
+        return
+    end
+    return (midigrid.midi_id ~= nil)
+end
+
+
+-- led handling. *generally speaking*; first we clear the unchanged led buffer...
+function midigrid:all(brightness)
+    local vel = brightness_handler(brightness)
+    if midigrid.device then
+        for row = 1, midigrid.rows do
+            for col = 1, midigrid.cols do
+                if grid_buf[row][col] ~= brightness then -- this led needs to be set
+                    grid_buf[row][col] = brightness
+                    if (quad == 1 and (col < 9 and row < 9)) then
+                        local note = grid_notes[row][col]
+                        if caps["sysex"] and caps["rgb"] then
+                            local sysex = config:all_led_sysex(vel)
+                            for _, byte in ipairs(sysex) do
+                                table.insert(midigrid.led_buf, byte)
+                            end
+                        else
+                            table.insert(midigrid.led_buf, 0x90)
+                            table.insert(midigrid.led_buf, note)
+                            table.insert(midigrid.led_buf, vel)
+                        end
+                    elseif (quad == 2 and (col > 8 and row < 9)) then
+                        local note = grid_notes[row][col - 8]
+                        if caps["sysex"] and caps["rgb"] then
+                            local sysex = config:all_led_sysex(vel)
+                            for _, byte in ipairs(sysex) do
+                                table.insert(midigrid.led_buf, byte)
+                            end
+                        else
+                            table.insert(midigrid.led_buf, 0x90)
+                            table.insert(midigrid.led_buf, note)
+                            table.insert(midigrid.led_buf, vel)
+                        end
+                    elseif (quad == 3 and (col < 9 and row > 8)) then
+                        local note = grid_notes[row - 8][col]
+                        if caps["sysex"] and caps["rgb"] then
+                            local sysex = config:all_led_sysex(vel)
+                            for _, byte in ipairs(sysex) do
+                                table.insert(midigrid.led_buf, byte)
+                            end
+                        else
+                            table.insert(midigrid.led_buf, 0x90)
+                            table.insert(midigrid.led_buf, note)
+                            table.insert(midigrid.led_buf, vel)
+                        end
+                    elseif (quad == 4 and (col > 8 and row > 8)) then
+                        local note = grid_notes[row - 8][col - 8]
+                        if caps["sysex"] and caps["rgb"] then
+                            local sysex = config:all_led_sysex(vel)
+                            for _, byte in ipairs(sysex) do
+                                table.insert(midigrid.led_buf, byte)
+                            end
+                        else
+                            table.insert(midigrid.led_buf, 0x90)
+                            table.insert(midigrid.led_buf, note)
+                            table.insert(midigrid.led_buf, vel)
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+
+-- ...then we update the led buf at our leisure...
+function midigrid:led(col, row, brightness)
+    if (col >= 1 and row >= 1) and (col <= midigrid.cols and row <= midigrid.rows) then
+        local vel = brightness_handler(brightness)
+        local note = nil
+        grid_buf[row][col] = brightness
+
+        -- if we aint in the right quad dont bother
+        if (col >= 9 or row >= 9) and quad == 1 then
+            return
+        end
+        if (col <= 8 or row >= 9) and quad == 2 then
+            return
+        end
+        if (col >= 9 or row <= 8) and quad == 3 then
+            return
+        end
+        if (col <= 8 or row <= 8) and quad == 4 then
+            return
+        end
+        if midigrid.device then
+            if quad == 1 then
+                note = grid_notes[row][col]
+            elseif quad == 2 then
+                note = grid_notes[row][col - 8]
+            elseif quad == 3 then
+                note = grid_notes[row - 8][col]
+            elseif quad == 4 then
+                note = grid_notes[row - 8][col - 8]
+            end
+            if note then
+                if caps["sysex"] and caps["rgb"] then
+                    local sysex = config:led_sysex(note, vel)
+                    for _, byte in ipairs(sysex) do
+                        table.insert(midigrid.led_buf, byte)
+                    end
+                else
+                    table.insert(midigrid.led_buf, 0x90)
+                    table.insert(midigrid.led_buf, note)
+                    table.insert(midigrid.led_buf, vel)
+                end
+            else
+                print("no note found! coordinates... x: " .. col .. " y: " .. row .. " z: " .. brightness)
+            end
+        end
+    end
+end
+
+
+-- ...then we send the whole buf at once
+function midigrid:refresh()
+    local local_grid = midi.devices[midigrid.midi_id]
+    if midigrid.device then
+        if caps['lp_double_buffer'] then
+            local_grid:send(config:display_double_buffer_sysex())
+        end
+        local_grid:send(midigrid.led_buf)
+
+        -- apparently, we need to refresh the quad button leds as well
+        if quad == 1 then
+            local_grid:note_on(upper_left_quad, 1)
+            local_grid:note_on(upper_right_quad, 0)
+            local_grid:note_on(lower_left_quad, 0)
+            local_grid:note_on(lower_right_quad, 0)
+        elseif quad == 2 then
+            local_grid:note_on(upper_left_quad, 0)
+            local_grid:note_on(upper_right_quad, 1)
+            local_grid:note_on(lower_left_quad, 0)
+            local_grid:note_on(lower_right_quad, 0)
+        elseif quad == 3 then
+            local_grid:note_on(upper_left_quad, 0)
+            local_grid:note_on(upper_right_quad, 0)
+            local_grid:note_on(lower_left_quad, 1)
+            local_grid:note_on(lower_right_quad, 0)
+        elseif quad == 4 then
+            local_grid:note_on(upper_left_quad, 0)
+            local_grid:note_on(upper_right_quad, 0)
+            local_grid:note_on(lower_left_quad, 0)
+            local_grid:note_on(lower_right_quad, 1)
+        end
+
+        -- ...and clear the buffer again.
+        midigrid.led_buf = {}
+    else
+        print("Error: no device found")
+    end
+end
+
+
+-- surely there is more elegant way!
+function midigrid.changequad(quad)
+    midigrid.led_buf = {}
+    if quad == 1 then
+        for row = 1, midigrid.rows - 8 do
+            for col = 1, midigrid.cols - 8 do
+                midigrid:led(col, row, grid_buf[row][col])
+            end
+        end
+    elseif quad == 2 then
+        for row = 1, midigrid.rows - 8 do
+            for col = midigrid.cols - 7, midigrid.cols do
+                midigrid:led(col, row, grid_buf[row][col])
+            end
+        end
+    elseif quad == 3 then
+        for row = midigrid.rows - 7, midigrid.rows do
+            for col = 1, midigrid.cols - 8 do
+                midigrid:led(col, row, grid_buf[row][col])
+            end
+        end
+    elseif quad == 4 then
+        for row = midigrid.rows - 7, midigrid.rows do
+            for col = midigrid.cols - 7, midigrid.cols do
+                midigrid:led(col, row, grid_buf[row][col])
+            end
+        end
+    end
+    midigrid.refresh()
+end
+
+
+function midigrid.handle_key_midi(event)
+    -- type="note_on", note, vel, ch
+    -- type="cc", cc, val, ch
+    -- so, tldr, `event[2]` is what we want
+    local note = event[2]
+    local midi_msg = midi.to_msg(event)
+    local local_grid = midi.devices[midigrid.midi_id]
+
+    -- first, intercept quad selectors
+    if (note == upper_left_quad or note == upper_right_quad
+            or note == lower_left_quad or note == lower_right_quad) then
+        -- "musical" notes, i.e. the main 8x8 grid, are in this range, BUT these values are
+        -- device-dependent. Reject cc "notes" here.
+        if note == upper_left_quad
+                and (midi_msg.type == "note_on" or caps["cc_edge_buttons"])
+                and quad ~= 1 then
+            quad = 1
+            local_grid:note_on(upper_left_quad, 1)
+            local_grid:note_on(upper_right_quad, 0)
+            local_grid:note_on(lower_left_quad, 0)
+            local_grid:note_on(lower_right_quad, 0)
+            midigrid.changequad(quad)
+        elseif note == upper_right_quad
+                and (midi_msg.type == "note_on" or caps["cc_edge_buttons"])
+                and quad ~= 2 then
+            quad = 2
+            local_grid:note_on(upper_left_quad, 0)
+            local_grid:note_on(upper_right_quad, 1)
+            local_grid:note_on(lower_left_quad, 0)
+            local_grid:note_on(lower_right_quad, 0)
+            midigrid.changequad(quad)
+        elseif note == lower_left_quad
+                and (midi_msg.type == "note_on" or caps["cc_edge_buttons"])
+                and quad ~= 3 then
+            quad = 3
+            local_grid:note_on(upper_left_quad, 0)
+            local_grid:note_on(upper_right_quad, 0)
+            local_grid:note_on(lower_left_quad, 1)
+            local_grid:note_on(lower_right_quad, 0)
+            midigrid.changequad(quad)
+        elseif note == lower_right_quad
+                and (midi_msg.type == "note_on" or caps["cc_edge_buttons"])
+                and quad ~= 4 then
+            quad = 4
+            local_grid:note_on(upper_left_quad, 0)
+            local_grid:note_on(upper_right_quad, 0)
+            local_grid:note_on(lower_left_quad, 0)
+            local_grid:note_on(lower_right_quad, 1)
+            midigrid.changequad(quad)
+        else
+            -- possibly note_off
+        end
+    elseif (note >= 0 and note <= 88)
+            and (midi_msg.type == "note_on" or midi_msg.type == "note_off") then
+        local coords = note_coords[quad][note]
+        local state = 0
+        if coords then
+            local x, y
+            x, y = coords[1], coords[2]
+            if midi_msg.type == "note_on" then
+                state = 1
+            end
+            if midigrid.key ~= nil then
+                midigrid.key(x, y, state)
+            end
+        else
+            print("missing coords!")
+        end
+    end
+end
+
+midigrid.init()
+
+return midigrid


### PR DESCRIPTION
... This requires a little bit of refactoring for "2-page" mode, and the various device config files.

@miker2049; If you don't like the "midigrid_2page.lua" -> "mg_128.lua" rename, please don't hesitate to say so.

My rationale for that rename was a global idea of continuing from here, to split out an "mg_64.lua" from "midigrid.lua", and eventually refactor "midigrid.lua" to contain as much duplicated code from the "mg_*" as possible (note that I'm *not* promising to do this 😝).

Notes:
- **Important**: This PR already includes most of the work from PR #6 and #5, so really they need to go in first.
- Tested "midigrid.lua", "mg_128.lua", and "mg_256.lua" with awake, loom, and tutorial/9_grid.lua
- **Contributors who have access to the various devices which I *don't* (@jaggednz, @timm052, @ryanlaws), please add the new lower quad key note values for your device(s) to the relevant config file(s)**, otherwise 256 mode will only be 1/2 done 😁 