### PR TITLE
Remove cat-typing typo ¯\_(ツ)_/¯

### DIFF
--- a/lib/mg_256.lua
+++ b/lib/mg_256.lua
@@ -290,7 +290,7 @@ function midigrid:led(col, row, brightness)
             if note then
                 -- the result of the fn call becomes the arg to `_brightness_to_buffer`
                 _brightness_to_buffer(note, vel, config:led_sysex(note, vel))
-4            else
+            else
                 print("no note found! coordinates... x: " .. col .. " y: " .. row .. " z: " .. brightness)
             end
         end


### PR DESCRIPTION
Picture a keyboard left unattended... and a cat.

Add fatigue and, frankly, a lack of due diligence.

Thus we find ourselves here.