### PR TITLE
Fix max note

### DIFF
--- a/config/apcmini_config.lua
+++ b/config/apcmini_config.lua
@@ -10,6 +10,9 @@ local apcmini={
     {8,9,10,11,12,13,14,15},
     {0,1,2,3,4,5,6,7}
   },
+
+  max_note = 63,
+
   --here, the function expects a brightness_handler val and spits out another val so your midi controller can understand, these values are generally great for apc with most scripts, but will also need to be adjusted for other controllers!
   --corresponds here to the 4 available states on apc: 0(off), 1(green) , 3(yellow), 5(red)
   brightness_handler = function (val)

--- a/config/launchpad_config.lua
+++ b/config/launchpad_config.lua
@@ -11,6 +11,9 @@ local launchpad={
     {96,97,98,99,100,101,102,103},
     {112,113,114,115,116,117,118,119}
   },
+
+  max_note = 119,
+
   --here, the function expects a brightness_handler val and spits out another val so your midi controller can understand, these values are generally great for apc with most scripts, but will also need to be adjusted for other controllers!
   --corresponds here to the launchpad led settings found in the manual
   brightness_handler = function (val)

--- a/config/launchpadmini_config.lua
+++ b/config/launchpadmini_config.lua
@@ -11,6 +11,9 @@ local launchpad={
     {96,97,98,99,100,101,102,103},
     {112,113,114,115,116,117,118,119}
   },
+
+  max_note = 119,
+
   --here, the function expects a brightness_handler val and spits out another val so your midi controller can understand, these values are generally great for apc with most scripts, but will also need to be adjusted for other controllers!
   --corresponds here to the launchpad led settings found in the manual
   brightness_handler = function (val)

--- a/config/launchpadmk2_config.lua
+++ b/config/launchpadmk2_config.lua
@@ -14,6 +14,7 @@ local launchpad = {
       {11, 12, 13, 14, 15, 16, 17, 18}
   },
 
+  max_note = 88,
 
   --[[ values here correspond to the launchpad mk2 led settings found in the programmer's
            reference.

--- a/config/launchpadpro_config.lua
+++ b/config/launchpadpro_config.lua
@@ -18,6 +18,7 @@ local launchpad = {
         {11, 12, 13, 14, 15, 16, 17, 18}
     },
 
+    max_note = 88,
 
     --[[ values here correspond to the launchpad pro led settings found in the programmer's
              reference.

--- a/lib/core.lua
+++ b/lib/core.lua
@@ -48,6 +48,7 @@ function midigrid.init()
     end
     config = include(config_name)
     grid_notes = config.grid_notes
+    max_note = config.max_note
     brightness_handler = config.brightness_handler
     device_name = config.device_name
     og_dev_add = nil

--- a/lib/mg_128.lua
+++ b/lib/mg_128.lua
@@ -197,7 +197,7 @@ function midigrid.handle_key_midi(event)
         end
     -- "musical" notes, i.e. the main 8x8 grid, are in this range, BUT these values are
     -- device-dependent. Reject cc "notes" here.
-    -- elseif (note >= 0 and note <= 88)
+    -- elseif (note >= 0 and note <= max_note)
     elseif (midi_msg.type == 'note_on' or midi_msg.type == 'note_off') then
         local coords = view_note_coords[curr_view][note]
         local state = 0

--- a/lib/mg_128_cheat.lua
+++ b/lib/mg_128_cheat.lua
@@ -253,7 +253,7 @@ function midigrid.handle_key_midi(event)
         end
     -- "musical" notes, i.e. the main 8x8 grid, are in this range, BUT these values are
     -- device-dependent. Reject cc "notes" here.
-    -- elseif (note >= 0 and note <= 88)
+    -- elseif (note >= 0 and note <= max_note)
     elseif (midi_msg.type == 'note_on' or midi_msg.type == 'note_off') then
         local coords = view_note_coords[curr_view][note]
         local state = 0

--- a/lib/mg_256.lua
+++ b/lib/mg_256.lua
@@ -207,7 +207,7 @@ function midigrid.handle_key_midi(event)
         end
     -- "musical" notes, i.e. the main 8x8 grid, are in this range, BUT these values are
     -- device-dependent. Reject cc "notes" here.
-    -- elseif (note >= 0 and note <= 88)
+    -- elseif (note >= 0 and note <= max_note)
     elseif (midi_msg.type == 'note_on' or midi_msg.type == 'note_off') then
         local coords = view_note_coords[curr_view][note]
         local state = 0

--- a/lib/midigrid.lua
+++ b/lib/midigrid.lua
@@ -78,7 +78,7 @@ function midigrid.handle_key_midi(event)
 
     -- "musical" notes, i.e. the main 8x8 grid, are in this range, BUT these values are
     -- device-dependent. Reject cc "notes" here.
-    if (note >= 0 and note <= 88)
+    if (note >= 0 and note <= max_note)
             and (midi_msg.type == 'note_on' or midi_msg.type == 'note_off') then
         local coords = note_coords[note]
         local state = 0


### PR DESCRIPTION
The code had 88 hard-coded as the upper-limit of MIDI-notes, but the Launchpad configs had 119 as the highest note.
I've added a new config param, `max_note` so that each device can specify its own range. One could find the highest note in the `midi_notes` matrix but I went with a simpler solution.